### PR TITLE
Replace direct calls for scripts in the templates with proper calls in functions.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# Compiled source #
+###################
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.so
+
+# Packages #
+############
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.zip
+
+# Logs and databases #
+######################
+*.log
+*.sql
+*.sqlite
+
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## ASU Divi
 A child theme of Divi created for ASU. Current development site: 
-http://dev-faculty.ws.asu.edu/
+https://researchwebservices.rtd.asu.edu/
 
 
 ## Description

--- a/footer.php
+++ b/footer.php
@@ -47,19 +47,13 @@ if ( ! is_page_template( 'page-template-blank.php' ) ) : ?>
 
 	</div> <!-- #page-container -->
 
-	<?php wp_footer(); ?>
-
 	<!-- Begin ASU Footer -->
-	<?php
-	$request = wp_remote_get('http://www.asu.edu/asuthemes/4.6/includes/footer.shtml');
-	$response = wp_remote_retrieve_body( $request );
-	echo $response;
-	?>
+	<?php asuwp_load_global_footer(); ?>
 	<!-- END ASU Footer -->
 
-	<!-- Javascript -->
-	<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
-	<script src="/wp-content/themes/asu-divi/js/rtd.js"></script>
+	<?php wp_footer(); ?>
 
 </body>
 </html>
+
+

--- a/functions.php
+++ b/functions.php
@@ -20,7 +20,7 @@ function asuwp_enqueue_scripts() {
 }
 add_action( 'wp_enqueue_scripts', 'asuwp_enqueue_scripts' );
 
-// Load global assets via remote get.
+// Load global assets via remote get. Allows for easy access to the version in each of the URLs below.
 function asuwp_load_global_head_scripts() {
 	$request = wp_remote_get('http://www.asu.edu/asuthemes/4.6/heads/default.shtml');
 	$response = wp_remote_retrieve_body( $request );
@@ -40,3 +40,23 @@ function asuwp_load_global_footer() {
     echo $response;
 }
 
+// Add custom home icon & menu entry to main nav manu.
+function asuwp_add_home_menu_icon ( $items, $args ) {
+    if ($args->theme_location == 'primary-menu') {
+
+        if (is_home()) {
+            $homeicon = '<li id="menu-item-home" class="menu_item current-menu-item">';
+        } else {
+            $homeicon = '<li id="menu-item-home" class="menu_item">';
+        }
+
+        $homeicon .= '<a href="' . get_home_url() . '" title="Home" id="home-icon-main-nav">';
+        $homeicon .= '<span class="fa fa-home" aria-hidden="true"></span>';
+        $homeicon .= '</a>';
+        $homeicon .= '</li>';
+        
+        $items = $homeicon . $items;
+    }
+    return $items;
+}
+add_filter( 'wp_nav_menu_items', 'asuwp_add_home_menu_icon', 10, 2 );

--- a/functions.php
+++ b/functions.php
@@ -1,0 +1,42 @@
+<?php
+
+/* Register, enqueue scripts, execute action */
+function asuwp_enqueue_scripts() {
+    
+    wp_register_style( 'divi', get_template_directory_uri() . '/style.css');
+    wp_register_style( 'asu-divi', get_stylesheet_directory_uri().'/style.css', array('divi'), wp_get_theme()->get('Version'));
+    wp_register_style( 'font-awesome', 'https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css', false, '4.7.0' );
+    wp_register_style( 'roboto-font', 'https://fonts.googleapis.com/css?family=Roboto:300,300i,400,400i,500,500i,700,700i,900,900i');
+    
+    // wp_register_script( 'asu-header', 'https://www.asu.edu/asuthemes/4.6/heads/default.shtml', array() , '4.6', false );
+    
+    wp_enqueue_style( 'divi' );
+    wp_enqueue_style( 'asu-divi' );
+    wp_enqueue_style( 'font-awesome' );
+    wp_enqueue_style( 'roboto-font' );
+    
+    // wp_enqueue_script( 'asu-header' );
+
+}
+add_action( 'wp_enqueue_scripts', 'asuwp_enqueue_scripts' );
+
+// Load global assets via remote get.
+function asuwp_load_global_head_scripts() {
+	$request = wp_remote_get('http://www.asu.edu/asuthemes/4.6/heads/default.shtml');
+	$response = wp_remote_retrieve_body( $request );
+	echo $response;
+}
+
+function asuwp_load_global_header() {
+    $request = wp_remote_get('http://www.asu.edu/asuthemes/4.6/headers/default.shtml');
+    $response = wp_remote_retrieve_body( $request );
+    $response .= '<div class="header__sitename_wrapper"><a href="/" title="Home" rel="home" class="header__sitename">'. get_bloginfo( 'name' ) . '</a></span></div>';
+    echo $response;
+}
+
+function asuwp_load_global_footer() {
+    $request = wp_remote_get('http://www.asu.edu/asuthemes/4.6/includes/footer.shtml');
+    $response = wp_remote_retrieve_body( $request );
+    echo $response;
+}
+

--- a/header.php
+++ b/header.php
@@ -32,22 +32,15 @@
 
 	<?php wp_head(); ?>
 	<!-- Begin ASU Heads -->
-	<?php
-	$request = wp_remote_get('http://www.asu.edu/asuthemes/4.6/heads/default.shtml');
-	$response = wp_remote_retrieve_body( $request );
-	echo $response;
-	?>
+	<?php asuwp_load_global_head_scripts(); ?>
 	<!-- END ASU Heads -->
 </head>
 <body <?php body_class(); ?>>
-<!-- Begin ASU Headers -->
-<?php
-$request = wp_remote_get('http://www.asu.edu/asuthemes/4.6/headers/default.shtml');
-$response = wp_remote_retrieve_body( $request );
-echo $response;
-?>
-<div class="header__sitename_wrapper"><a href="/" title="Home" rel="home" class="header__sitename"><?php bloginfo( 'name' ); ?></a></span></div>
-<!-- End ASU Headers -->
+
+<!-- Begin ASU Header  -->
+<?php asuwp_load_global_header(); ?>
+<!-- END ASU Header -->
+
 <?php
 	$product_tour_enabled = et_builder_is_product_tour_enabled();
 	$page_container_style = $product_tour_enabled ? ' style="padding-top: 0px;"' : ''; ?>

--- a/js/rtd.js
+++ b/js/rtd.js
@@ -1,7 +1,0 @@
-var $jq = jQuery.noConflict();
-
-jQuery(document).ready(function($jq) {
-
-  $jq('#top-menu > li.menu-item-home').html('<a href=\'/\' class=\'keepsake\'><i class="fa fa-home"/></a>');
-
-});

--- a/style.css
+++ b/style.css
@@ -9,14 +9,6 @@
   GitHub Theme URI: https://github.com/ASU-OKED-WEB-DEV/asu-divi
 */
 
-@import url("../Divi/style.css");
-
-/*- CSS custom code -*/
-
-@import url('https://fonts.googleapis.com/css?family=Roboto:400,400i,500,500i,700,700i,900,900i');
-
-
-
 body {
   font-family: "Roboto", "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 18px;


### PR DESCRIPTION
Replace direct calls for scripts in the templates with proper calls in functions.php
- Centralizes code making for easier editing in the future.
- Allows plugins to deregister and reregister styles as needed.
- Calls child theme css as a dependancy of the parent theme css, replacing @import.
- Added .gitignore to the repo.